### PR TITLE
fixed a bug and some issues with retries:

### DIFF
--- a/src/Web/Options/LanguageBlobServiceOptions.cs
+++ b/src/Web/Options/LanguageBlobServiceOptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace DslCopilot.Web.Options;
-public record LanguageBlobServiceOptions(
-  string? AccessKey,
-  string? AccountName,
-  string? ContainerName
-);
+public class LanguageBlobServiceOptions
+{
+  public string? AccessKey { get; set; }
+  public string? AccountName { get; set; }
+  public string? ContainerName { get; set; }
+}

--- a/src/Web/Services/DslAIService.cs
+++ b/src/Web/Services/DslAIService.cs
@@ -1,4 +1,4 @@
-using Microsoft.KernelMemory;
+﻿using Microsoft.KernelMemory;
 using Microsoft.SemanticKernel;
 
 namespace DslCopilot.Web.Services;
@@ -17,7 +17,7 @@ public class DslAIService(
 
     if (chatHistory.Count == 0)
     {
-      chatHistory.AddSystemMessage($"You are an assistant for generating code that conforms to a given ANTLR grammar.  You only respond with code, and you only respond with code that conforms to this grammar: {antlrDef}");
+      chatHistory.AddSystemMessage($"You are an assistant for generating code that conforms to a given grammar.");
     }
 
     chatHistory.AddUserMessage(userMessage);

--- a/src/Web/plugins/generateCode.yaml
+++ b/src/Web/plugins/generateCode.yaml
@@ -1,7 +1,6 @@
 name: generateCode
 description: generates code snippets based on user input
 template: |
-  {{console-log "running generateCode"}}
   {{ConversationSummaryPlugin-SummarizeConversation history}}
 
   ## Instructions
@@ -32,6 +31,19 @@ template: |
 
   prompt: {{input}}
   respone: <result>
+
+  {{#if badCode}}
+  ## Code to be fixed
+  This example is almost correct!  But it contains errors:
+  {{badCode}}
+  {{/if}}
+  {{#if errors}}
+  ## Errors to fix
+  Here are the errors.  Make sure you fix them!:
+    {{#each errors}}
+    - {{this}}
+    {{/each}}
+  {{/if}}
 
   ## Response
 


### PR DESCRIPTION
* LanguageBlobServiceOptions is now an object rather than a record, because you need a parameterless constructor to do IOptions<T>.Value
* Made OnFunctionInvoked back to non-async from async, and went back to calling GetAwaiter().GetResult().  For some reason, when being called async, it exhibited the behavior I was initially afraid of, not actually returning from retry invocations.  Turning it back fixed this, but I'm curious as to why. 
* Removed the console-log plugin from the generateCode.yaml file, as that doesn't exist. 
* Removed the additional addition of the ANTLR grammar from directly being inserted into the conversation history, as with csharp having it in there twice ate up all the tokens just for that. 
* (more an enhancement) added the errors (conditionally) to the generateCode prompt, so the function is directly told "avoid these errors" when retrying.  It seems to work better.