### PR TITLE
Validation and compilation

### DIFF
--- a/src/Web/Components/Pages/Chat.razor
+++ b/src/Web/Components/Pages/Chat.razor
@@ -108,14 +108,7 @@
 
         // Call DslAIService to send chat message
         SpinnerVisibility = "visible";
-        newMessage.Response = await AIService.AskAI(newMessage.Message, MyDsl.AntlrDef, _cts.Token);
-
-        // await foreach (var chunk in response)
-        // {
-        //   responseString += chunk;
-        //   newMessage.Response = Markdig.Markdown.ToHtml(responseString);
-        //   await InvokeAsync(StateHasChanged);
-        // }
+        newMessage.Response = await AIService.AskAI(newMessage.Message, selectedLanguage, MyDsl.AntlrDef, _cts.Token);
 
         SpinnerVisibility = "hidden";
         await InvokeAsync(StateHasChanged);

--- a/src/Web/FunctionFilters/CodeRetryFunctionFilter.cs
+++ b/src/Web/FunctionFilters/CodeRetryFunctionFilter.cs
@@ -35,7 +35,10 @@ public class CodeRetryFunctionFilter(ChatSessionService chatSessionService, Cons
       return;
     }
 
-    var result = CSharpCodeValidator.ValidateCode(code);
+    var codeValidator = CodeValidatorFactory.GetValidator("csharp");
+    consoleService.WriteToConsole(chatSessionId, $"Validating generated code with {codeValidator.Name}");
+
+    var result = codeValidator.ValidateCode(code);
     if (!result.IsValid)
     {
       _numRetries.TryAdd(operationId, 0);

--- a/src/Web/FunctionFilters/CodeRetryFunctionFilter.cs
+++ b/src/Web/FunctionFilters/CodeRetryFunctionFilter.cs
@@ -28,6 +28,13 @@ public class CodeRetryFunctionFilter(ChatSessionService chatSessionService, Cons
       return;
     }
 
+    var language = context.Arguments["language"]?.ToString();
+    if (string.IsNullOrEmpty(language))
+    {
+      return;
+    }
+
+
     var code = context.Result.GetValue<string>();
     if (string.IsNullOrEmpty(code))
     {
@@ -35,7 +42,7 @@ public class CodeRetryFunctionFilter(ChatSessionService chatSessionService, Cons
       return;
     }
 
-    var codeValidator = CodeValidatorFactory.GetValidator("csharp");
+    var codeValidator = CodeValidatorFactory.GetValidator(language);
     consoleService.WriteToConsole(chatSessionId, $"Validating generated code with {codeValidator.Name}");
 
     var result = codeValidator.ValidateCode(code);

--- a/src/Web/Services/DslAIService.cs
+++ b/src/Web/Services/DslAIService.cs
@@ -8,7 +8,7 @@ public class DslAIService(
   ChatSessionIdService chatSessionIdService,
   ChatSessionService chatSessionService)
 {
-  public async Task<string> AskAI(string userMessage, string antlrDef, CancellationToken cancellationToken)
+  public async Task<string> AskAI(string userMessage, string language, string antlrDef, CancellationToken cancellationToken)
   {
     var chatSessionId = chatSessionIdService.GetChatSessionId();
     var chatHistory = chatSessionService.GetChatSession(chatSessionId);
@@ -29,6 +29,7 @@ public class DslAIService(
       {
         { "input", userMessage },
         { "history", string.Join(Environment.NewLine, chatHistory) },
+        { "language", language },
         { "grammar", antlrDef },
         { "fewShotExamples", fewShotExamples },
         { "chatSessionId", chatSessionId },

--- a/src/Web/Validators/CSharpCodeValidator.cs
+++ b/src/Web/Validators/CSharpCodeValidator.cs
@@ -1,13 +1,15 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static System.Environment;
 
 namespace DslCopilot.Web.Validators;
-public static class CSharpCodeValidator
+public class CSharpCodeValidator : ICodeValidator
 {
-  public static CodeValidationResult ValidateCode(string input)
+  public string Name => nameof(CSharpCodeValidator);
+
+  public CodeValidationResult ValidateCode(string input)
   {
     CodeValidationResult? result;
     try

--- a/src/Web/Validators/CodeValidatorFactory.cs
+++ b/src/Web/Validators/CodeValidatorFactory.cs
@@ -1,0 +1,16 @@
+﻿namespace DslCopilot.Web.Validators
+{
+  public static class CodeValidatorFactory
+  {
+    public static ICodeValidator GetValidator(string language)
+    {
+      switch (language)
+      {
+        case "csharp":
+          return new CSharpCodeValidator();
+        default:
+         return new NullCodeValidator();
+      }
+    }
+  }
+}

--- a/src/Web/Validators/ICodeValidator.cs
+++ b/src/Web/Validators/ICodeValidator.cs
@@ -1,0 +1,8 @@
+﻿namespace DslCopilot.Web.Validators
+{
+  public interface ICodeValidator
+  {
+    CodeValidationResult ValidateCode(string input);
+    string Name { get; }
+  }
+}

--- a/src/Web/Validators/NullCodeValidator.cs
+++ b/src/Web/Validators/NullCodeValidator.cs
@@ -1,0 +1,16 @@
+﻿namespace DslCopilot.Web.Validators
+{
+  public class NullCodeValidator : ICodeValidator
+  {
+    public string Name => nameof(NullCodeValidator);
+
+    public CodeValidationResult ValidateCode(string input)
+    {
+      return new CodeValidationResult
+      {
+        IsValid = true,
+        Errors = []
+      };
+    }
+  }
+}


### PR DESCRIPTION
Code validation is now pluggable.  The language is passed as a parameter to Semantic Kernel, and the filter dynamically selects a code validator.  It currently only supports csharp (as before), but will otherwise run a NullCodeValidator which does nothing and returns an empty valid result.  